### PR TITLE
Make sed invocations POSIX complient (portable)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -55,7 +55,9 @@
  (target debugger_sexp_printbox.log)
  (action (progn
   (run %{dep:test_debug_sexp.exe})
-  (run sed -i "s/[0-9]\\+-[0-9]\\+-[0-9]\\+ [0-9]\\+:[0-9]\\+:[0-9]\\+\\.[0-9]\\+\\( +[0-9]\\+:[0-9]\\+\\)\\?/YYYY-MM-DD HH:MM:SS.NNNNNN/g" %{target}))))
+  (copy %{target} %{target}.tmp)
+  (with-stdout-to %{target}
+   (run sed "s/[0-9]\\+-[0-9]\\+-[0-9]\\+ [0-9]\\+:[0-9]\\+:[0-9]\\+\\.[0-9]\\+\\( +[0-9]\\+:[0-9]\\+\\)\\?/YYYY-MM-DD HH:MM:SS.NNNNNN/g" %{target}.tmp)))))
 
 (rule
  (alias runtest)
@@ -73,7 +75,9 @@
  (target debugger_pp_format.log)
  (action (progn
   (run %{dep:test_debug_pp.exe})
-  (run sed -i "s/[0-9]\\+-[0-9]\\+-[0-9]\\+ [0-9]\\+:[0-9]\\+:[0-9]\\+\\.[0-9]\\+\\( +[0-9]\\+:[0-9]\\+\\)\\?/YYYY-MM-DD HH:MM:SS.NNNNNN/g" %{target}))))
+  (copy %{target} %{target}.tmp)
+  (with-stdout-to %{target}
+   (run sed "s/[0-9]\\+-[0-9]\\+-[0-9]\\+ [0-9]\\+:[0-9]\\+:[0-9]\\+\\.[0-9]\\+\\( +[0-9]\\+:[0-9]\\+\\)\\?/YYYY-MM-DD HH:MM:SS.NNNNNN/g" %{target}.tmp)))))
 
 (rule
  (alias runtest)
@@ -91,7 +95,9 @@
  (target debugger_show_flushing.log)
  (action (progn
   (run %{dep:test_debug_show.exe})
-  (run sed -i "s/[0-9]\\+-[0-9]\\+-[0-9]\\+ [0-9]\\+:[0-9]\\+:[0-9]\\+\\.[0-9]\\+\\( +[0-9]\\+:[0-9]\\+\\)\\?/YYYY-MM-DD HH:MM:SS.NNNNNN/g" %{target}))))
+  (copy %{target} %{target}.tmp)
+  (with-stdout-to %{target}
+   (run sed "s/[0-9]\\+-[0-9]\\+-[0-9]\\+ [0-9]\\+:[0-9]\\+:[0-9]\\+\\.[0-9]\\+\\( +[0-9]\\+:[0-9]\\+\\)\\?/YYYY-MM-DD HH:MM:SS.NNNNNN/g" %{target}.tmp)))))
 
 (rule
  (alias runtest)


### PR DESCRIPTION
Will otherwise fail with:
```
#=== ERROR while compiling ppx_minidebug.0.3.1 ================================#
# context              2.1.4 | macos/arm64 | ocaml-base-compiler.4.14.1 | pinned(https://github.com/lukstafi/ppx_minidebug/releases/download/0.3.1/ppx_minidebug-0.3.1.tbz)
# path                 ~/.opam/4.14.1/.opam-switch/build/ppx_minidebug.0.3.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_minidebug -j 7 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/ppx_minidebug-68217-82c680.env
# output-file          ~/.opam/log/ppx_minidebug-68217-82c680.out
### output ###
# File "test/dune", line 72, characters 0-241:
# 72 | (rule
# 73 |  (target debugger_pp_format.log)
# 74 |  (action (progn
# 75 |   (run %{dep:test_debug_pp.exe})
# 76 |   (run sed -i "s/[0-9]\\+-[0-9]\\+-[0-9]\\+ [0-9]\\+:[0-9]\\+:[0-9]\\+\\.[0-9]\\+\\( +[0-9]\\+:[0-9]\\+\\)\\?/YYYY-MM-DD HH:MM:SS.NNNNNN/g" %{target}))))
# (cd _build/default/test && /usr/bin/sed -i 's/[0-9]\+-[0-9]\+-[0-9]\+ [0-9]\+:[0-9]\+:[0-9]\+\.[0-9]\+\( +[0-9]\+:[0-9]\+\)\?/YYYY-MM-DD HH:MM:SS.NNNNNN/g' debugger_pp_format.log)
# sed: 1: "debugger_pp_format.log": extra characters at the end of d command
# File "test/dune", line 90, characters 0-247:
# 90 | (rule
# 91 |  (target debugger_show_flushing.log)
# 92 |  (action (progn
# 93 |   (run %{dep:test_debug_show.exe})
# 94 |   (run sed -i "s/[0-9]\\+-[0-9]\\+-[0-9]\\+ [0-9]\\+:[0-9]\\+:[0-9]\\+\\.[0-9]\\+\\( +[0-9]\\+:[0-9]\\+\\)\\?/YYYY-MM-DD HH:MM:SS.NNNNNN/g" %{target}))))
# (cd _build/default/test && /usr/bin/sed -i 's/[0-9]\+-[0-9]\+-[0-9]\+ [0-9]\+:[0-9]\+:[0-9]\+\.[0-9]\+\( +[0-9]\+:[0-9]\+\)\?/YYYY-MM-DD HH:MM:SS.NNNNNN/g' debugger_show_flushing.log)
# sed: 1: "debugger_show_flushing.log": extra characters at the end of d command
# File "test/dune", line 54, characters 0-247:
# 54 | (rule
# 55 |  (target debugger_sexp_printbox.log)
# 56 |  (action (progn
# 57 |   (run %{dep:test_debug_sexp.exe})
# 58 |   (run sed -i "s/[0-9]\\+-[0-9]\\+-[0-9]\\+ [0-9]\\+:[0-9]\\+:[0-9]\\+\\.[0-9]\\+\\( +[0-9]\\+:[0-9]\\+\\)\\?/YYYY-MM-DD HH:MM:SS.NNNNNN/g" %{target}))))
# (cd _build/default/test && /usr/bin/sed -i 's/[0-9]\+-[0-9]\+-[0-9]\+ [0-9]\+:[0-9]\+:[0-9]\+\.[0-9]\+\( +[0-9]\+:[0-9]\+\)\?/YYYY-MM-DD HH:MM:SS.NNNNNN/g' debugger_sexp_printbox.log)
# sed: 1: "debugger_sexp_printbox.log": extra characters at the end of d command
```
Noticed on https://github.com/ocaml/opam-repository/pull/23594