### PR TITLE
Make ToC channel lazy to avoid file creation at log_level 0

### DIFF
--- a/minidebug_runtime.ml
+++ b/minidebug_runtime.ml
@@ -1225,6 +1225,27 @@ module PrintBox (Log_to : Shared_config) = struct
           else None)
 
   let get_toc_ch () = Lazy.force toc_ch_lazy
+  let lazy_toc_snapshot = ref 0
+
+  let snapshot_ch () =
+    snapshot_ch ();
+    match get_toc_ch () with
+    | None -> ()
+    | Some _ when table_of_contents_ch <> None ->
+        (* Already handled by Log_to.snapshot_ch *)
+        ()
+    | Some toc_ch ->
+        flush toc_ch;
+        lazy_toc_snapshot := pos_out toc_ch
+
+  let reset_to_snapshot () =
+    reset_to_snapshot ();
+    match get_toc_ch () with
+    | None -> ()
+    | Some _ when table_of_contents_ch <> None ->
+        (* Already handled by Log_to.reset_to_snapshot *)
+        ()
+    | Some toc_ch -> seek_out toc_ch !lazy_toc_snapshot
 
   let should_log_path fname message =
     match config.path_filter with

--- a/minidebug_runtime.ml
+++ b/minidebug_runtime.ml
@@ -146,7 +146,7 @@ let shared_config ?(time_tagged = Not_tagged) ?(elapsed_times = elapsed_default)
     let debug_ch_name () = !current_ch_name
 
     let table_of_contents_ch =
-      if with_table_of_contents then (
+      if with_table_of_contents && log_level > 0 then (
         let suffix = Filename.extension filename in
         let filename = Filename.remove_extension filename ^ "-toc" ^ suffix in
         let ch =
@@ -1159,6 +1159,7 @@ type printbox_config = {
   mutable flame_graph_separation : int;
   mutable prev_run_file : string option;
   mutable path_filter : [ `Whitelist of Re.re | `Blacklist of Re.re ] option;
+  mutable for_append : bool;
 }
 
 module type PrintBox_runtime = sig
@@ -1197,7 +1198,33 @@ module PrintBox (Log_to : Shared_config) = struct
       flame_graph_separation = 40;
       prev_run_file = None;
       path_filter = Log_to.path_filter;
+      for_append = true;
     }
+
+  let toc_ch_lazy =
+    lazy
+      (match table_of_contents_ch with
+      | Some _ -> table_of_contents_ch
+      | None ->
+          if
+            (config.with_toc_listing || config.toc_flame_graph)
+            && Filename.extension (debug_ch_name ()) <> ""
+          then (
+            let name = debug_ch_name () in
+            let suffix = Filename.extension name in
+            let toc_name =
+              Filename.remove_extension name ^ "-toc" ^ suffix
+            in
+            let ch =
+              if config.for_append then
+                open_out_gen [ Open_creat; Open_append ] 0o640 toc_name
+              else open_out toc_name
+            in
+            Gc.finalise (fun _ -> close_out ch) ch;
+            Some ch)
+          else None)
+
+  let get_toc_ch () = Lazy.force toc_ch_lazy
 
   let should_log_path fname message =
     match config.path_filter with
@@ -1469,7 +1496,7 @@ module PrintBox (Log_to : Shared_config) = struct
       { scope_id; depth; toc_depth = result_toc_depth; size; elapsed; body; time_tag; _ }
       =
     let span = Mtime.Span.abs_diff elapsed_on_close elapsed in
-    match table_of_contents_ch with
+    match get_toc_ch () with
     | None -> (toc_depth, B.empty, B.empty)
     | _ when not @@ toc_entry_passes ~depth ~size ~span toc_entry ->
         (toc_depth, B.empty, B.empty)
@@ -1635,7 +1662,7 @@ module PrintBox (Log_to : Shared_config) = struct
       pop_snapshot ();
       output_box ~for_toc:false ch box;
       PrevRun.signal_chunk_end !prev_run_state;
-      (match table_of_contents_ch with
+      (match get_toc_ch () with
       | None -> ()
       | Some toc_ch ->
           let toc_depth, toc_header, toc_box =
@@ -2165,6 +2192,7 @@ let debug_file ?(time_tagged = Not_tagged) ?(elapsed_times = elapsed_default)
               ~verbose_scope_ids ~global_prefix ~for_append ?split_files_after
               ~with_table_of_contents ~toc_entry ~log_level ?path_filter filename)) in
   Debug.config.backend <- backend;
+  Debug.config.for_append <- for_append;
   Debug.config.boxify_sexp_from_size <- boxify_sexp_from_size;
   Debug.config.max_inline_sexp_length <- max_inline_sexp_length;
   Debug.config.highlight_terms <- Option.map Re.compile highlight_terms;

--- a/minidebug_runtime.mli
+++ b/minidebug_runtime.mli
@@ -284,6 +284,10 @@ type printbox_config = {
       (** If provided, filters logs based on source file paths and entry names at runtime.
           The filter is applied to ["fname/message"]. [`Whitelist re] only outputs logs
           matching the regex; [`Blacklist re] suppresses logs matching the regex. *)
+  mutable for_append : bool;
+      (** If true, the lazily created Table of Contents file is opened in append mode.
+          If false, the file is truncated on creation. Defaults to [true]; {!debug_file}
+          sets this to its own [~for_append] parameter (which defaults to [false]). *)
 }
 
 module type PrintBox_runtime = sig

--- a/test/dune
+++ b/test/dune
@@ -283,6 +283,22 @@
   (pps ppx_minidebug ppx_deriving.show)))
 
 (executable
+ (name test_toc_no_file_at_level0)
+ (modules test_toc_no_file_at_level0)
+ (libraries minidebug_runtime)
+ (modes exe))
+
+(rule
+ (alias runtest-toc-no-file-at-level0)
+ (action
+  (run %{dep:test_toc_no_file_at_level0.exe})))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{dep:test_toc_no_file_at_level0.exe})))
+
+(executable
  (name test_debug_log_prefixed)
  (modules test_debug_log_prefixed)
  (libraries minidebug_db)

--- a/test/test_toc_no_file_at_level0.ml
+++ b/test/test_toc_no_file_at_level0.ml
@@ -1,0 +1,21 @@
+let () =
+  let stem = "debugger_toc_no_file_at_level0" in
+  let log_file = stem ^ ".log" in
+  let toc_file = stem ^ "-toc.log" in
+  (* Clean up any leftover files from previous runs *)
+  (try Sys.remove log_file with Sys_error _ -> ());
+  (try Sys.remove toc_file with Sys_error _ -> ());
+  (* Create a runtime with log_level=0 and with_toc_listing=true *)
+  let module Debug_runtime =
+    (val Minidebug_runtime.debug_file ~log_level:0 ~with_toc_listing:true
+           stem)
+  in
+  ignore (module Debug_runtime : Minidebug_runtime.PrintBox_runtime);
+  (* Verify neither file was created *)
+  if Sys.file_exists log_file then (
+    Printf.eprintf "FAIL: %s should not exist at log_level 0\n" log_file;
+    exit 1);
+  if Sys.file_exists toc_file then (
+    Printf.eprintf "FAIL: %s should not exist at log_level 0\n" toc_file;
+    exit 1);
+  print_endline "PASS: no log or toc file created at log_level 0"


### PR DESCRIPTION
## Summary

- Gate ToC file creation on `log_level > 0` in `shared_config` (covers Flushing backend)
- Add lazy `get_toc_ch()` in `PrintBox` functor that creates the ToC file on first access using `config.with_toc_listing`/`toc_flame_graph` and `debug_ch_name()`, supporting runtime `log_level` changes
- Add `for_append` field to `printbox_config` so the lazy path respects the caller's open mode
- Add test verifying no files created at `log_level 0` with `with_toc_listing=true`
- `Shared_config` public API unchanged (`table_of_contents_ch : out_channel option`)

Fixes #60

## Test plan

- [x] `dune build @runtest-toc-no-file-at-level0` passes
- [x] `dune runtest` passes (all existing tests, no regressions)
- [x] Rebased onto latest main (includes PR #104 snapshot_toc changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)