### PR TITLE
TUI: add mouse event support: clicking and wheel scrolling

### DIFF
--- a/client/interactive.ml
+++ b/client/interactive.ml
@@ -282,6 +282,9 @@ type command =
   | InputBackspace
   | InputEscape
   | InputEnter
+  | ClickAt of int (* visible_items index to move cursor to *)
+  | ScrollUp of int (* move cursor up by N items *)
+  | ScrollDown of int (* move cursor down by N items *)
 
 (** Find closest ancestor with positive ID by walking up the tree *)
 let rec find_positive_ancestor_id (module Q : Query.S) scope_id =
@@ -1404,6 +1407,38 @@ let rec handle_command state command ~height =
             else state.scroll_offset
           in
           Some { state with cursor = new_cursor; scroll_offset = new_scroll })
+  | ClickAt index ->
+      let max_cursor = Array.length state.visible_items - 1 in
+      if max_cursor < 0 then Some state
+      else
+        let new_cursor = max 0 (min index max_cursor) in
+        let new_scroll =
+          if new_cursor < state.scroll_offset then new_cursor
+          else if new_cursor >= state.scroll_offset + content_height then
+            new_cursor - content_height + 1
+          else state.scroll_offset
+        in
+        Some { state with cursor = new_cursor; scroll_offset = new_scroll }
+  | ScrollUp n ->
+      let max_cursor = Array.length state.visible_items - 1 in
+      if max_cursor < 0 then Some state
+      else
+        let new_cursor = max 0 (state.cursor - n) in
+        let new_scroll = max 0 (min state.scroll_offset new_cursor) in
+        Some { state with cursor = new_cursor; scroll_offset = new_scroll }
+  | ScrollDown n ->
+      let max_cursor = Array.length state.visible_items - 1 in
+      if max_cursor < 0 then Some state
+      else
+        let new_cursor = min max_cursor (state.cursor + n) in
+        let new_scroll =
+          if new_cursor >= state.scroll_offset + content_height then
+            min
+              (max 0 (max_cursor - content_height + 1))
+              (new_cursor - content_height + 1)
+          else state.scroll_offset
+        in
+        Some { state with cursor = new_cursor; scroll_offset = new_scroll }
   | ToggleExpansion -> Some (toggle_expansion state)
   | Fold -> Some (fold_selection state)
   | SearchNext -> (
@@ -1785,6 +1820,12 @@ let parse_command_string str =
   | "M" -> Some GotoPrevHighlight
   | "esc" | "escape" -> Some InputEscape
   | "backspace" -> Some InputBackspace
+  | "scrollup" -> Some (ScrollUp 3)
+  | "scrolldown" -> Some (ScrollDown 3)
+  | _ when String.length str > 6 && String.sub str 0 6 = "click " ->
+      let rest = String.sub str 6 (String.length str - 6) in
+      (try Some (ClickAt (int_of_string (String.trim rest)))
+       with Failure _ -> None)
   | _ when String.length str > 0 && str.[0] = '/' ->
       (* Search command: /term *)
       let term = String.sub str 1 (String.length str - 1) in

--- a/client/tui.ml
+++ b/client/tui.ml
@@ -316,6 +316,9 @@ let render_lines ~width ~is_selected ~show_times ~margin_width ~search_slots
         in
         [ render_single_line truncated ]
 
+(** Row-to-item mapping for mouse click resolution. Updated on each render. *)
+let last_row_to_item : int array ref = ref [||]
+
 (** Render the full screen *)
 let render_screen state ~width ~height =
   let header_height = 2 in
@@ -446,6 +449,7 @@ let render_screen state ~width ~height =
   let content_lines = ref [] in
   let lines_rendered = ref 0 in
   let i = ref visible_start in
+  let row_to_item = Array.make (max 0 content_height) (-1) in
 
   (* Render items until we fill content_height or run out of items *)
   while !lines_rendered < content_height && !i < num_items do
@@ -460,11 +464,13 @@ let render_screen state ~width ~height =
     List.iter
       (fun line ->
         if !lines_rendered < content_height then (
+          row_to_item.(!lines_rendered) <- !i;
           content_lines := line :: !content_lines;
           incr lines_rendered))
       item_lines;
     incr i
   done;
+  last_row_to_item := row_to_item;
 
   (* Pad if needed *)
   let padding_lines = content_height - !lines_rendered in
@@ -490,7 +496,7 @@ let render_screen state ~width ~height =
                   "[↑/↓] Navigate | [Home/End] First/Last | [PgUp/PgDn] Page | [u/d] \
                    Quarter | [n/N] Next/Prev Match | [m/M] Goto+Expand | [Enter/Space] \
                    Expand | [f] Fold | [/] Search | [g] Goto | [Q] Quiet | [t] Times | \
-                   [v] Values | [o] Order | [q] Quit"))
+                   [v] Values | [o] Order | [q] Quit | Mouse: Click/Scroll"))
     in
     NI.vcat
       [
@@ -508,7 +514,30 @@ let parse_key state event =
   | None -> None
   | Some (`Resize _) -> None
   | Some `End -> Some I.Quit
-  | Some (`Mouse _) -> None
+  | Some (`Mouse (event, (_x, y), _mods)) ->
+      (* Ignore mouse in any input mode *)
+      if
+        Option.is_some state.I.quiet_path_input
+        || Option.is_some state.I.search_input
+        || Option.is_some state.I.goto_input
+      then None
+      else (
+        let header_height = 2 in
+        match event with
+        | `Press `Left ->
+            let content_row = y - header_height in
+            if
+              content_row >= 0
+              && content_row < Array.length !last_row_to_item
+              && !last_row_to_item.(content_row) >= 0
+            then
+              let item_idx = !last_row_to_item.(content_row) in
+              if item_idx = state.I.cursor then Some I.ToggleExpansion
+              else Some (I.ClickAt item_idx)
+            else None
+        | `Press (`Scroll `Up) -> Some (I.ScrollUp 3)
+        | `Press (`Scroll `Down) -> Some (I.ScrollDown 3)
+        | _ -> None)
   | Some (`Paste _) -> None
   | Some (`Key (key : Unescape.key)) -> (
       match state.I.quiet_path_input with
@@ -555,7 +584,7 @@ let parse_key state event =
               | _ -> None)))
 
 let create_tui_callbacks () =
-  let term = Term.create () in
+  let term = Term.create ~mouse:true () in
   let command_stream state = parse_key state @@ event_with_timeout term 0.2 in
   let finalize () = Term.release term in
   let render_screen state ~width ~height =

--- a/docs/task-d3ede2d6-proposal.md
+++ b/docs/task-d3ede2d6-proposal.md
@@ -1,0 +1,48 @@
+# Proposal: ppx_minidebug PR #102 followups
+
+**Task**: task-d3ede2d6
+**Project**: ppx_minidebug
+**PR**: https://github.com/lukstafi/ppx_minidebug/pull/102
+
+## Goal
+
+Clean up two follow-up items from the dune instrumentation backend PR (#102):
+
+1. **Extract `is_auto_eligible` predicate**: The eligibility check for auto-instrumentation (is this binding a non-unit, non-runtime-setup, function expression that is not already instrumented?) is written out identically in three places. Extract it into a single named function.
+
+2. **Document `instrumentation.backend` flags gotcha**: Dune's `(instrumentation.backend ...)` stanza in `dune-project` does not support a `flags` field. Users must pass `--auto` on the consumer side via `(instrumentation (backend ppx_minidebug --auto))` in each library/executable's `dune` file. This is non-obvious and should be documented in the README.
+
+## Acceptance Criteria
+
+- [ ] A top-level `is_auto_eligible : value_binding -> bool` function is defined in `ppx_minidebug.ml` that checks: `not (is_unit_pattern vb.pvb_pat) && not (is_runtime_setup_binding vb) && is_function_expr vb.pvb_expr && not (is_already_instrumented vb)`
+- [ ] The local `is_eligible_binding` inside `needs_runtime_injection` (line ~810) is replaced with a call to `is_auto_eligible`
+- [ ] The inline predicate in `any_eligible` (lines ~2130-2136) is replaced with a call to `is_auto_eligible`
+- [ ] The inline predicate in the `List.map` filter (lines ~2143-2147) is replaced with a call to `is_auto_eligible`
+- [ ] README.md includes a section (or note in an existing section) explaining how to pass `--auto` when using dune instrumentation, with a concrete `dune` file example showing `(instrumentation (backend ppx_minidebug --auto))`
+- [ ] The README note clarifies that `(instrumentation.backend ...)` in `dune-project` does NOT accept a `flags` field
+- [ ] All existing tests pass (`dune runtest`)
+
+## Context
+
+### Duplication locations in `ppx_minidebug.ml`
+
+**Location 1** -- `needs_runtime_injection` (line ~809): defines a local `is_eligible_binding` with the same 4-conjunct check.
+
+**Location 2** -- `transform_item` / `any_eligible` (line ~2130): inline `List.exists` with identical 4-conjunct predicate.
+
+**Location 3** -- `transform_item` / `List.map` filter (line ~2143): inline `if` guard with identical 4-conjunct predicate.
+
+### README gap
+
+The README currently has no section about dune instrumentation or the `--auto` flag. The `--auto` flag and related `--auto-mode`, `--auto-log-value`, `--auto-db-base-name` options are only documented via `Driver.add_arg` doc strings in the source.
+
+## Approach
+
+1. Define `let is_auto_eligible vb = ...` near the existing helper functions (around line 808, just before `needs_runtime_injection`).
+2. Replace all three occurrences with calls to `is_auto_eligible`.
+3. Add a "Dune Instrumentation Backend" section to the README (near the end, before "Related projects") with:
+   - Brief explanation of `--auto` mode
+   - `dune-project` stanza example: `(instrumentation.backend (ppx ppx_minidebug))`
+   - Consumer-side `dune` file example: `(instrumentation (backend ppx_minidebug --auto))`
+   - Explicit note about the flags gotcha
+4. Run `dune runtest` to confirm no regressions.


### PR DESCRIPTION
## Summary
- Mouse left-click on a visible item row selects it; click on already-selected expandable item toggles expansion
- Mouse scroll wheel moves cursor up/down by 3 items
- Mouse events ignored during input modes (search, goto, quiet path)
- DB-backed TUI supports `click <n>`, `scrollup`, `scrolldown` via `parse_command_string`
- `Term.create ~mouse:true` made explicit; footer help text updated

Closes #103

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` — no regressions from this change
- [ ] Manual TUI test: click rows, scroll wheel, verify input mode ignores mouse
- [ ] tmux with `set -g mouse on`

🤖 Generated with [Claude Code](https://claude.com/claude-code)