### PR TITLE
Extract is_auto_eligible predicate; document instrumentation flags gotcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,33 @@ See the `test/` directory for extensive examples:
 - [test_expect_test.ml](test/test_expect_test.ml) — Comprehensive test suite with 60+ examples
 - [test_path_filter.ml](test/test_path_filter.ml) — Path filtering examples
 
+## Dune Instrumentation Backend
+
+ppx_minidebug supports dune's [instrumentation](https://dune.readthedocs.io/en/stable/instrumentation.html) mechanism. With `--auto` mode, all eligible top-level function bindings are automatically instrumented without requiring `let%debug_*` annotations.
+
+Enable it in your `dune-project`:
+
+```
+(lang dune 3.0)
+(instrumentation.backend (ppx ppx_minidebug))
+```
+
+Then pass `--auto` on the **consumer side** in each library or executable `dune` file:
+
+```
+(library
+ (name my_lib)
+ (instrumentation (backend ppx_minidebug --auto)))
+```
+
+> **Important:** Dune's `(instrumentation.backend ...)` stanza in `dune-project` does **not** support a `flags` field. You cannot pass `--auto` there — it must be specified in the per-library/executable `(instrumentation (backend ppx_minidebug --auto))` stanza.
+
+Additional auto-mode flags:
+
+- `--auto-mode {sexp|pp|show}` — Choose the logging serializer (default: `sexp`)
+- `--auto-log-value {args-and-result|result-only}` — What to log (default: `args-and-result`)
+- `--auto-db-base-name <name>` — Override the database file base name (default: `debugger_<source-file>`)
+
 ## Related Tools
 
 - [`ppx_debug`](https://github.com/dariusf/ppx_debug) — Complementary PPX with different design trade-offs

--- a/ppx_minidebug.ml
+++ b/ppx_minidebug.ml
@@ -801,18 +801,21 @@ let is_already_instrumented vb =
   in
   check_body vb.pvb_expr
 
+(* Check if a binding is eligible for auto-instrumentation:
+   non-unit, not a runtime setup binding, a function expression,
+   and not already instrumented by context-free rules. *)
+let is_auto_eligible vb =
+  (not (is_unit_pattern vb.pvb_pat))
+  && (not (is_runtime_setup_binding vb))
+  && is_function_expr vb.pvb_expr
+  && not (is_already_instrumented vb)
+
 (* Check if Debug_runtime is defined before the first eligible function.
    Returns true if we need to inject a Debug_runtime module.
    This is called from the impl hook, so already-instrumented bindings
    (from context-free rules) must be excluded.
    Returns false if there are no eligible functions at all. *)
 let needs_runtime_injection str =
-  let is_eligible_binding vb =
-    (not (is_unit_pattern vb.pvb_pat))
-    && (not (is_runtime_setup_binding vb))
-    && is_function_expr vb.pvb_expr
-    && not (is_already_instrumented vb)
-  in
   let rec scan = function
     | [] -> false (* no eligible functions found *)
     | si :: rest -> (
@@ -820,7 +823,7 @@ let needs_runtime_injection str =
         | Pstr_module { pmb_name = { txt = Some "Debug_runtime"; _ }; _ } ->
             false (* found user's Debug_runtime before any eligible function *)
         | Pstr_value (_, bindings)
-          when List.exists is_eligible_binding bindings ->
+          when List.exists is_auto_eligible bindings ->
             true (* found eligible function before Debug_runtime *)
         | _ -> scan rest)
   in
@@ -2128,23 +2131,13 @@ let auto_instrument_impl str =
       match si.pstr_desc with
       | Pstr_value (rec_flag, bindings) ->
           let any_eligible =
-            List.exists
-              (fun vb ->
-                (not (is_unit_pattern vb.pvb_pat))
-                && (not (is_runtime_setup_binding vb))
-                && is_function_expr vb.pvb_expr
-                && not (is_already_instrumented vb))
-              bindings
+            List.exists is_auto_eligible bindings
           in
           if any_eligible then
             let bindings =
               List.map
                 (fun vb ->
-                  if
-                    (not (is_unit_pattern vb.pvb_pat))
-                    && (not (is_runtime_setup_binding vb))
-                    && is_function_expr vb.pvb_expr
-                    && not (is_already_instrumented vb)
+                  if is_auto_eligible vb
                   then
                     let original_constraint = vb.pvb_constraint in
                     let result =


### PR DESCRIPTION
## Summary

- Extract a single `is_auto_eligible` predicate in `ppx_minidebug.ml` to replace three identical 4-conjunct eligibility checks (in `needs_runtime_injection`, `any_eligible`, and the `List.map` filter)
- Add "Dune Instrumentation Backend" section to README documenting that `--auto` must be passed on the consumer side via `(instrumentation (backend ppx_minidebug --auto))`, since `dune-project`'s `(instrumentation.backend ...)` stanza does not support a `flags` field

## Test plan

- [x] `dune runtest` passes with no diffs — pure refactor, no behavior change
- [x] Verify `is_auto_eligible` is used in all three original locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)